### PR TITLE
Add a basic logger handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const { Command } = require('commander')
 const { getConfig } = require('./src/config')
 const { projectCategories, dbSettings } = getConfig()
+const { logger } = require('./src/utils')
 const { runAddProjectCommand, runWorkflowCommand, listWorkflowCommand } = require('./src/cli')
 const knex = require('knex')(dbSettings)
 
@@ -19,7 +20,7 @@ project
     try {
       await runAddProjectCommand(knex, options)
     } catch (error) {
-      console.error('Error adding project:', error.message)
+      logger.error('Error adding project:', error.message)
       process.exit(1)
     } finally {
       await knex.destroy()
@@ -37,7 +38,7 @@ workflow
     try {
       await runWorkflowCommand(knex, options)
     } catch (error) {
-      console.error('Error running workflow:', error.message)
+      logger.error('Error running workflow:', error.message)
       process.exit(1)
     } finally {
       await knex.destroy()

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "lint": "standard",
     "lint:fix": "standard --fix",
-    "test": "jest",
-    "test:coverage": "jest --coverage",
-    "test:ci": "jest --runInBand --verbose --coverage",
+    "test": "NODE_ENV=test jest",
+    "test:coverage": "NODE_ENV=test jest --coverage",
+    "test:ci": "NODE_ENV=test jest --runInBand --verbose --coverage",
     "infra:start": "docker-compose up -d",
     "infra:stop": "docker-compose down",
     "db:migrate": "knex migrate:latest",

--- a/src/cli/workflows.js
+++ b/src/cli/workflows.js
@@ -1,5 +1,6 @@
-const { updateGithubOrgs } = require('../workflows')
 const inquirer = require('inquirer').default
+const { updateGithubOrgs } = require('../workflows')
+const { logger } = require('../utils')
 
 const commandList = [{
   name: 'update-github-orgs',
@@ -9,8 +10,8 @@ const commandList = [{
 const validCommandNames = commandList.map(({ name }) => name)
 
 function listWorkflowCommand (options = {}) {
-  console.log('Available workflows:')
-  console.log(commandList.map(({ name, description }) => `- ${name}: ${description}`).join('\n'))
+  logger.log('Available workflows:')
+  logger.log(commandList.map(({ name, description }) => `- ${name}: ${description}`).join('\n'))
   return commandList
 }
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -8,7 +8,22 @@ const ensureGithubToken = () => {
   }
 }
 
+const defineLog = (type) => function () {
+  if (process.env.NODE_ENV === 'test') {
+    return () => {}
+  }
+  return console[type](...arguments)
+}
+
+const logger = {
+  info: defineLog('info'),
+  error: defineLog('error'),
+  warn: defineLog('warn'),
+  log: defineLog('log')
+}
+
 module.exports = {
   validateGithubUrl,
-  ensureGithubToken
+  ensureGithubToken,
+  logger
 }

--- a/src/workflows/index.js
+++ b/src/workflows/index.js
@@ -2,6 +2,7 @@ const debug = require('debug')('workflows')
 const { simplifyObject } = require('@ulisesgascon/simplify-object')
 const { github } = require('../providers')
 const { initializeStore } = require('../store')
+const { logger } = require('../utils')
 
 const mapOrgData = (data) => {
   const mappedData = simplifyObject(data, {
@@ -51,7 +52,7 @@ const updateGithubOrgs = async (knex) => {
     debug('Updating organization in database')
     await updateGithubOrganization(mappedData)
   }))
-  console.log('GitHub organizations updated successfully')
+  logger.log('GitHub organizations updated successfully')
 }
 
 module.exports = {


### PR DESCRIPTION
### Main Changes

Add a basic logger handler that makes the tests more readable when debugging (c919623 and d4870e2)

#### Tests
- Hardcode `NODE_ENV` to `test` in this environment to silence the logs (ace5833)

### Changelog
- c919623 feat: add a basic logger handler by @UlisesGascon
- d4870e2 chore: use logger directly by @UlisesGascon
- ace5833 test: hardcode `NODE_ENV` to `test` in this environment by @UlisesGascon