### PR TITLE
Add JSON schema validation to the GH API responses

### DIFF
--- a/src/schemas/githubOrganization.json
+++ b/src/schemas/githubOrganization.json
@@ -82,13 +82,19 @@
         ]
       },
       "name": {
-        "type": "string",
+        "type": [
+          "string", 
+          "null"
+        ],
         "examples": [
           "github"
         ]
       },
       "company": {
-        "type": "string",
+        "type": [
+          "string",
+          "null"
+        ],
         "examples": [
           "GitHub"
         ]
@@ -101,13 +107,19 @@
         ]
       },
       "location": {
-        "type": "string",
+        "type": [
+          "string",
+          "null"
+        ],
         "examples": [
           "San Francisco"
         ]
       },
       "email": {
-        "type": "string",
+        "type": [
+          "string",
+          "null"
+        ],
         "format": "email",
         "examples": [
           "octocat@github.com"

--- a/src/schemas/index.js
+++ b/src/schemas/index.js
@@ -9,7 +9,8 @@ const validateGithubOrg = (data) => {
   const validate = ajv.compile(githubOrganizationSchema)
   const valid = validate(data)
   if (!valid) {
-    throw new Error(validate.errors.map((error) => error.message).join('\n'))
+    const readableErrors = validate.errors.map((error) => `[ERROR: ${error.keyword}]${error.schemaPath}: ${error.message}`).join('\n')
+    throw new Error(`Error when validating the Github org response from API: ${readableErrors}`)
   }
   return null
 }

--- a/src/workflows/index.js
+++ b/src/workflows/index.js
@@ -3,6 +3,7 @@ const { simplifyObject } = require('@ulisesgascon/simplify-object')
 const { github } = require('../providers')
 const { initializeStore } = require('../store')
 const { logger } = require('../utils')
+const { validateGithubOrg } = require('../schemas')
 
 const mapOrgData = (data) => {
   const mappedData = simplifyObject(data, {
@@ -47,6 +48,8 @@ const updateGithubOrgs = async (knex) => {
   await Promise.all(organizations.map(async (org) => {
     debug(`Fetching details for org (${org.login})`)
     const data = await github.fetchOrgByLogin(org.login)
+    debug('Validating data')
+    validateGithubOrg(data)
     debug('Transforming data')
     const mappedData = mapOrgData(data)
     debug('Updating organization in database')


### PR DESCRIPTION
### Main Changes
- Add json schema validation to the GH API responses (42decf6)
- Improve schema errors for human readability (f3897c9)
- Align the GitHub schema to the current API responses (6acb57c)

### Screenshots

This is the new and more friendly approach to showcase the errors:

![Screenshot from 2024-12-05 09-45-39](https://github.com/user-attachments/assets/ceb062e0-18d4-4ea8-ba0f-ca474f3dd7fe)

```
Format: `[ERROR: ${error.keyword}]${error.schemaPath}: ${error.message}`
Example: Error running workflow: Error when validating the Github org response from API: [ERROR: type]#/properties/location/type: must be string
```


### Changelog
- 42decf6 feat: add json schema validation to the GH API responses by @UlisesGascon
- f3897c9 feat: Improve schema errors for human readability by @UlisesGascon
- 6acb57c feat: align the GitHub schema to the current API responses by @UlisesGascon
