### PR TITLE
Add workflow `upsert-github-repositories`

### DIFF
--- a/__tests__/cli/__snapshots__/workflows.test.js.snap
+++ b/__tests__/cli/__snapshots__/workflows.test.js.snap
@@ -5,6 +5,12 @@ exports[`list - Non-Interactive Mode Should provide a list of available workflow
   {
     "description": "Check the organizations stored and update the information with the GitHub API.",
     "name": "update-github-orgs",
+    "workflow": [Function],
+  },
+  {
+    "description": "Check the organizations stored and update/create the information related to the repositories with the GitHub API.",
+    "name": "upsert-github-repositories",
+    "workflow": [Function],
   },
 ]
 `;

--- a/__tests__/cli/workflows.test.js
+++ b/__tests__/cli/workflows.test.js
@@ -1,10 +1,11 @@
 const inquirer = require('inquirer').default
 const knexInit = require('knex')
+const { simplifyObject } = require('@ulisesgascon/simplify-object')
 const { getConfig } = require('../../src/config')
 const { runWorkflowCommand, listWorkflowCommand } = require('../../src/cli')
-const { resetDatabase, getAllProjects, getAllGithubOrgs, addGithubOrg, addProject } = require('../../__utils__')
+const { resetDatabase, getAllProjects, getAllGithubOrgs, addGithubOrg, addProject, getAllGithubRepos, addGithubRepo } = require('../../__utils__')
 const { github } = require('../../src/providers')
-const { sampleGithubOrg } = require('../../__fixtures__')
+const { sampleGithubOrg, sampleGithubListOrgRepos, sampleGithubRepository } = require('../../__fixtures__')
 
 const { dbSettings } = getConfig('test')
 
@@ -47,23 +48,23 @@ describe('run GENERIC - Non-Interactive Mode', () => {
 })
 
 describe('run update-github-orgs', () => {
-  // Mock inquirer for testing
-  jest.spyOn(inquirer, 'prompt').mockImplementation(async (questions) => {
-    const questionMap = {
-      'What is the name of the workflow?': 'update-github-orgs'
-    }
-    return questions.reduce((acc, question) => {
-      acc[question.name] = questionMap[question.message]
-      return acc
-    }, {})
-  })
+  // // Mock inquirer for testing
+  // jest.spyOn(inquirer, 'prompt').mockImplementation(async (questions) => {
+  //   const questionMap = {
+  //     'What is the name of the workflow?': 'update-github-orgs'
+  //   }
+  //   return questions.reduce((acc, question) => {
+  //     acc[question.name] = questionMap[question.message]
+  //     return acc
+  //   }, {})
+  // })
 
   test('Should throw an error when no Github orgs are stored in the database', async () => {
     const projects = await getAllProjects(knex)
     expect(projects.length).toBe(0)
     const githubOrgs = await getAllGithubOrgs(knex)
     expect(githubOrgs.length).toBe(0)
-    await expect(runWorkflowCommand(knex, {}))
+    await expect(runWorkflowCommand(knex, { name: 'update-github-orgs' }))
       .rejects
       .toThrow('No organizations found. Please add organizations/projects before running this workflow.')
   })
@@ -79,12 +80,70 @@ describe('run update-github-orgs', () => {
     expect(githubOrgs[0].description).toBe(null)
     // Mock the fetchOrgByLogin method
     jest.spyOn(github, 'fetchOrgByLogin').mockResolvedValue(sampleGithubOrg)
-    await runWorkflowCommand(knex, {})
+    await runWorkflowCommand(knex, { name: 'update-github-orgs' })
     // Check the database changes
     githubOrgs = await getAllGithubOrgs(knex)
     expect(githubOrgs.length).toBe(1)
     expect(githubOrgs[0].description).toBe(sampleGithubOrg.description)
   })
 
+  test.todo('Should throw an error when the Github API is not available')
+})
+
+describe('run upsert-github-repositories', () => {
+  test('Should throw an error when no Github orgs are stored in the database', async () => {
+    const projects = await getAllProjects(knex)
+    expect(projects.length).toBe(0)
+    const githubOrgs = await getAllGithubOrgs(knex)
+    expect(githubOrgs.length).toBe(0)
+    await expect(runWorkflowCommand(knex, { name: 'upsert-github-repositories' }))
+      .rejects
+      .toThrow('No organizations found. Please add organizations/projects before running this workflow.')
+  })
+  test('Should add the repositories related to the organization', async () => {
+    // Prepare the database
+    const project = await addProject(knex, { name: sampleGithubOrg.login, category: 'impact' })
+    await addGithubOrg(knex, { login: sampleGithubOrg.login, html_url: sampleGithubOrg.html_url, project_id: project.id })
+    const projects = await getAllProjects(knex)
+    expect(projects.length).toBe(1)
+    const githubOrgs = await getAllGithubOrgs(knex)
+    expect(githubOrgs.length).toBe(1)
+    let githubRepos = await getAllGithubRepos(knex)
+    expect(githubRepos.length).toBe(0)
+    // Mock the github methods used
+    jest.spyOn(github, 'fetchOrgReposListByLogin').mockResolvedValue(sampleGithubListOrgRepos)
+    jest.spyOn(github, 'fetchRepoByFullName').mockResolvedValue(sampleGithubRepository)
+    await runWorkflowCommand(knex, { name: 'upsert-github-repositories' })
+    // Check the database changes
+    githubRepos = await getAllGithubRepos(knex)
+    expect(githubRepos.length).toBe(1)
+    expect(githubRepos[0].description).toBe(sampleGithubRepository.description)
+  })
+  test('Should update the repositories related to the organization', async () => {
+    // Prepare the database
+    const project = await addProject(knex, { name: sampleGithubOrg.login, category: 'impact' })
+    const org = await addGithubOrg(knex, { login: sampleGithubOrg.login, html_url: sampleGithubOrg.html_url, project_id: project.id })
+    const githubRepoData = simplifyObject(sampleGithubRepository, {
+      include: ['node_id', 'name', 'full_name', 'html_url', 'url', 'git_url', 'ssh_url', 'clone_url', 'visibility', 'default_branch']
+    })
+    githubRepoData.github_organization_id = org.id
+    githubRepoData.description = 'existing data'
+    await addGithubRepo(knex, githubRepoData)
+    const projects = await getAllProjects(knex)
+    expect(projects.length).toBe(1)
+    const githubOrgs = await getAllGithubOrgs(knex)
+    expect(githubOrgs.length).toBe(1)
+    let githubRepos = await getAllGithubRepos(knex)
+    expect(githubRepos.length).toBe(1)
+    expect(githubRepos[0].description).toBe('existing data')
+    // Mock the github methods used
+    jest.spyOn(github, 'fetchOrgReposListByLogin').mockResolvedValue(sampleGithubListOrgRepos)
+    jest.spyOn(github, 'fetchRepoByFullName').mockResolvedValue(sampleGithubRepository)
+    await runWorkflowCommand(knex, { name: 'upsert-github-repositories' })
+    // Check the database changes
+    githubRepos = await getAllGithubRepos(knex)
+    expect(githubRepos.length).toBe(1)
+    expect(githubRepos[0].description).toBe(sampleGithubRepository.description)
+  })
   test.todo('Should throw an error when the Github API is not available')
 })

--- a/__utils__/index.js
+++ b/__utils__/index.js
@@ -1,4 +1,5 @@
 const resetDatabase = async (knex) => {
+  await knex.raw('TRUNCATE TABLE github_repositories RESTART IDENTITY CASCADE')
   await knex.raw('TRUNCATE TABLE github_organizations RESTART IDENTITY CASCADE')
   await knex.raw('TRUNCATE TABLE projects RESTART IDENTITY CASCADE')
 }
@@ -16,10 +17,18 @@ const addGithubOrg = async (knex, data) => {
   return githubOrg
 }
 
+const getAllGithubRepos = (knex) => knex('github_repositories').select('*')
+const addGithubRepo = async (knex, data) => {
+  const [githubRepo] = await knex('github_repositories').insert(data).returning('*')
+  return githubRepo
+}
+
 module.exports = {
   resetDatabase,
   getAllProjects,
   getAllGithubOrgs,
   addProject,
-  addGithubOrg
+  addGithubOrg,
+  getAllGithubRepos,
+  addGithubRepo
 }

--- a/src/cli/workflows.js
+++ b/src/cli/workflows.js
@@ -1,10 +1,16 @@
 const inquirer = require('inquirer').default
-const { updateGithubOrgs } = require('../workflows')
+const debug = require('debug')('cli:workflows')
+const { updateGithubOrgs, upsertGithubRepositories } = require('../workflows')
 const { logger } = require('../utils')
 
 const commandList = [{
   name: 'update-github-orgs',
-  description: 'Check the organizations stored and update the information with the GitHub API.'
+  description: 'Check the organizations stored and update the information with the GitHub API.',
+  workflow: updateGithubOrgs
+}, {
+  name: 'upsert-github-repositories',
+  description: 'Check the organizations stored and update/create the information related to the repositories with the GitHub API.',
+  workflow: upsertGithubRepositories
 }]
 
 const validCommandNames = commandList.map(({ name }) => name)
@@ -32,9 +38,9 @@ async function runWorkflowCommand (knex, options = {}) {
       }
     ])
 
-  if (answers.name === 'update-github-orgs') {
-    await updateGithubOrgs(knex)
-  }
+  const command = commandList.find(({ name }) => name === answers.name)
+  debug(`Running workflow: ${command.name}`)
+  await command.workflow(knex)
 
   return answers
 }

--- a/src/database/migrations/1733435340266_add_github_repos.js
+++ b/src/database/migrations/1733435340266_add_github_repos.js
@@ -1,0 +1,94 @@
+exports.up = async (knex) => {
+  // Create 'github_repositories' table
+  await knex.schema.createTable('github_repositories', (table) => {
+    table.increments('id').primary() // Primary key
+    table.string('node_id').unique().notNullable()
+    table.string('name').notNullable()
+    table.string('full_name').notNullable()
+    table.string('html_url').notNullable()
+    table.text('description')
+    table.boolean('fork')
+    table.string('url').notNullable()
+    table.string('git_url').notNullable()
+    table.string('ssh_url').notNullable()
+    table.string('clone_url').notNullable()
+    table.string('svn_url')
+    table.string('homepage')
+    table.integer('size')
+    table.integer('stargazers_count')
+    table.integer('watchers_count')
+    table.string('language')
+    table.boolean('has_issues')
+    table.boolean('has_projects')
+    table.boolean('has_downloads')
+    table.boolean('has_wiki')
+    table.boolean('has_pages')
+    table.boolean('has_discussions')
+    table.integer('forks_count')
+    table.string('mirror_url')
+    table.boolean('archived')
+    table.boolean('disabled')
+    table.integer('open_issues_count')
+    table.boolean('allow_forking')
+    table.boolean('is_template')
+    table.boolean('web_commit_signoff_required')
+    table.specificType('topics', 'text[]') // Array of strings
+    table.enu('visibility', ['public', 'private', 'internal']).notNullable()
+    table.string('default_branch').notNullable()
+    table.boolean('allow_squash_merge')
+    table.boolean('allow_merge_commit')
+    table.boolean('allow_rebase_merge')
+    table.boolean('allow_auto_merge')
+    table.boolean('delete_branch_on_merge')
+    table.boolean('allow_update_branch')
+    table.boolean('use_squash_pr_title_as_default')
+    table.string('squash_merge_commit_message')
+    table.string('squash_merge_commit_title')
+    table.string('merge_commit_message')
+    table.string('merge_commit_title')
+    table.integer('network_count')
+    table.integer('subscribers_count')
+    table.integer('github_repo_id').unique()
+    table.timestamp('github_created_at')
+    table.timestamp('github_updated_at')
+    table.timestamp('github_archived_at')
+    table.string('license_key')
+    table.string('license_name')
+    table.string('license_spdx_id')
+    table.string('license_url')
+    table.string('license_node_id')
+    table.enu('secret_scanning_status', ['enabled', 'disabled']).defaultTo('disabled')
+    table.enu('secret_scanning_push_protection_status', ['enabled', 'disabled']).defaultTo('disabled')
+    table.enu('dependabot_security_updates_status', ['enabled', 'disabled']).defaultTo('disabled')
+    table.enu('secret_scanning_non_provider_patterns_status', ['enabled', 'disabled']).defaultTo('disabled')
+    table.enu('secret_scanning_validity_checks_status', ['enabled', 'disabled']).defaultTo('disabled')
+
+    // Foreign key to 'github_organizations' table
+    table
+      .integer('github_organization_id')
+      .unsigned()
+      .references('id')
+      .inTable('github_organizations')
+      .onDelete('CASCADE') // Deletes repository if the organization is deleted
+      .onUpdate('CASCADE') // Updates repository if the organization ID is updated
+
+    // Timestamps
+    table.timestamp('created_at').defaultTo(knex.fn.now()).notNullable()
+    table.timestamp('updated_at').defaultTo(knex.fn.now()).notNullable()
+  })
+
+  // Add trigger to 'github_repositories' table
+  await knex.raw(`
+      CREATE TRIGGER set_updated_at_github_repositories
+      BEFORE UPDATE ON github_repositories
+      FOR EACH ROW
+      EXECUTE FUNCTION update_updated_at_column();
+    `)
+}
+
+exports.down = async (knex) => {
+  // Drop trigger
+  await knex.raw('DROP TRIGGER IF EXISTS set_updated_at_github_repositories ON github_repositories;')
+  // Drop table
+  await knex.schema.dropTableIfExists('github_repositories')
+}

--- a/src/database/schema/schema.sql
+++ b/src/database/schema/schema.sql
@@ -116,6 +116,104 @@ ALTER SEQUENCE public.github_organizations_id_seq OWNED BY public.github_organiz
 
 
 --
+-- Name: github_repositories; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.github_repositories (
+    id integer NOT NULL,
+    node_id character varying(255) NOT NULL,
+    name character varying(255) NOT NULL,
+    full_name character varying(255) NOT NULL,
+    html_url character varying(255) NOT NULL,
+    description text,
+    fork boolean,
+    url character varying(255) NOT NULL,
+    git_url character varying(255) NOT NULL,
+    ssh_url character varying(255) NOT NULL,
+    clone_url character varying(255) NOT NULL,
+    svn_url character varying(255),
+    homepage character varying(255),
+    size integer,
+    stargazers_count integer,
+    watchers_count integer,
+    language character varying(255),
+    has_issues boolean,
+    has_projects boolean,
+    has_downloads boolean,
+    has_wiki boolean,
+    has_pages boolean,
+    has_discussions boolean,
+    forks_count integer,
+    mirror_url character varying(255),
+    archived boolean,
+    disabled boolean,
+    open_issues_count integer,
+    allow_forking boolean,
+    is_template boolean,
+    web_commit_signoff_required boolean,
+    topics text[],
+    visibility text NOT NULL,
+    default_branch character varying(255) NOT NULL,
+    allow_squash_merge boolean,
+    allow_merge_commit boolean,
+    allow_rebase_merge boolean,
+    allow_auto_merge boolean,
+    delete_branch_on_merge boolean,
+    allow_update_branch boolean,
+    use_squash_pr_title_as_default boolean,
+    squash_merge_commit_message character varying(255),
+    squash_merge_commit_title character varying(255),
+    merge_commit_message character varying(255),
+    merge_commit_title character varying(255),
+    network_count integer,
+    subscribers_count integer,
+    github_repo_id integer,
+    github_created_at timestamp with time zone,
+    github_updated_at timestamp with time zone,
+    github_archived_at timestamp with time zone,
+    license_key character varying(255),
+    license_name character varying(255),
+    license_spdx_id character varying(255),
+    license_url character varying(255),
+    license_node_id character varying(255),
+    secret_scanning_status text DEFAULT 'disabled'::text,
+    secret_scanning_push_protection_status text DEFAULT 'disabled'::text,
+    dependabot_security_updates_status text DEFAULT 'disabled'::text,
+    secret_scanning_non_provider_patterns_status text DEFAULT 'disabled'::text,
+    secret_scanning_validity_checks_status text DEFAULT 'disabled'::text,
+    github_organization_id integer,
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT github_repositories_dependabot_security_updates_status_check CHECK ((dependabot_security_updates_status = ANY (ARRAY['enabled'::text, 'disabled'::text]))),
+    CONSTRAINT github_repositories_secret_scanning_non_provider_patterns_check CHECK ((secret_scanning_non_provider_patterns_status = ANY (ARRAY['enabled'::text, 'disabled'::text]))),
+    CONSTRAINT github_repositories_secret_scanning_push_protection_statu_check CHECK ((secret_scanning_push_protection_status = ANY (ARRAY['enabled'::text, 'disabled'::text]))),
+    CONSTRAINT github_repositories_secret_scanning_status_check CHECK ((secret_scanning_status = ANY (ARRAY['enabled'::text, 'disabled'::text]))),
+    CONSTRAINT github_repositories_secret_scanning_validity_checks_statu_check CHECK ((secret_scanning_validity_checks_status = ANY (ARRAY['enabled'::text, 'disabled'::text]))),
+    CONSTRAINT github_repositories_visibility_check CHECK ((visibility = ANY (ARRAY['public'::text, 'private'::text, 'internal'::text])))
+);
+
+
+--
+-- Name: github_repositories_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.github_repositories_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: github_repositories_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.github_repositories_id_seq OWNED BY public.github_repositories.id;
+
+
+--
 -- Name: knex_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -219,6 +317,13 @@ ALTER TABLE ONLY public.github_organizations ALTER COLUMN id SET DEFAULT nextval
 
 
 --
+-- Name: github_repositories id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.github_repositories ALTER COLUMN id SET DEFAULT nextval('public.github_repositories_id_seq'::regclass);
+
+
+--
 -- Name: knex_migrations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -264,6 +369,30 @@ ALTER TABLE ONLY public.github_organizations
 
 
 --
+-- Name: github_repositories github_repositories_github_repo_id_unique; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.github_repositories
+    ADD CONSTRAINT github_repositories_github_repo_id_unique UNIQUE (github_repo_id);
+
+
+--
+-- Name: github_repositories github_repositories_node_id_unique; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.github_repositories
+    ADD CONSTRAINT github_repositories_node_id_unique UNIQUE (node_id);
+
+
+--
+-- Name: github_repositories github_repositories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.github_repositories
+    ADD CONSTRAINT github_repositories_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: knex_migrations_lock knex_migrations_lock_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -295,6 +424,13 @@ CREATE TRIGGER set_updated_at_github_organizations BEFORE UPDATE ON public.githu
 
 
 --
+-- Name: github_repositories set_updated_at_github_repositories; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER set_updated_at_github_repositories BEFORE UPDATE ON public.github_repositories FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+
+--
 -- Name: projects set_updated_at_projects; Type: TRIGGER; Schema: public; Owner: -
 --
 
@@ -307,6 +443,14 @@ CREATE TRIGGER set_updated_at_projects BEFORE UPDATE ON public.projects FOR EACH
 
 ALTER TABLE ONLY public.github_organizations
     ADD CONSTRAINT github_organizations_project_id_foreign FOREIGN KEY (project_id) REFERENCES public.projects(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+
+--
+-- Name: github_repositories github_repositories_github_organization_id_foreign; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.github_repositories
+    ADD CONSTRAINT github_repositories_github_organization_id_foreign FOREIGN KEY (github_organization_id) REFERENCES public.github_organizations(id) ON UPDATE CASCADE ON DELETE CASCADE;
 
 
 --

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -12,8 +12,39 @@ const fetchOrgByLogin = async (login) => {
   return data
 }
 
+const fetchOrgReposListByLogin = async (login) => {
+  debug(`Fetching organization (${login}) repositories...`)
+  ensureGithubToken()
+  const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN })
+  let repoList = []
+
+  // IMPORTANT: Ignore private repositories as they might contain sensitive information
+  const orgQuery = { org: login, type: 'public', per_page: 100 }
+
+  const { data: repos } = await octokit.rest.repos.listForOrg(orgQuery)
+  debug(`Got ${repos.length} repos for org: ${login}`)
+  repoList = repoList.concat(repos)
+
+  // IMPORTANT: If the org has 100 repos it might require pagination management
+  if (repoList.length === 100) {
+    let page = 2
+    let hasMore = true
+    while (hasMore) {
+      debug(`Getting page ${page} for org: ${login}`)
+      const { data: repos, headers } = await octokit.rest.repos.listForOrg({ ...orgQuery, page })
+      debug(`Got ${repos.length} repos for org: ${login}`)
+      repoList = repoList.concat(repos)
+      hasMore = headers.link.includes('rel="next"')
+      page += 1
+    }
+  }
+
+  return repoList
+}
+
 const github = {
-  fetchOrgByLogin
+  fetchOrgByLogin,
+  fetchOrgReposListByLogin,
 }
 
 module.exports = {

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -42,9 +42,21 @@ const fetchOrgReposListByLogin = async (login) => {
   return repoList
 }
 
+const fetchRepoByFullName = async (fullName) => {
+  debug(`Fetching repository (${fullName})...`)
+  ensureGithubToken()
+  const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN })
+  const { data } = await octokit.request('GET /repos/{owner}/{repo}', {
+    owner: fullName.split('/')[0],
+    repo: fullName.split('/')[1]
+  })
+  return data
+}
+
 const github = {
   fetchOrgByLogin,
   fetchOrgReposListByLogin,
+  fetchRepoByFullName
 }
 
 module.exports = {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,5 +1,16 @@
 const debug = require('debug')('store')
 
+const upsertGithubRepository = knex => async (repository, orgId) => {
+  debug(`Upserting repository (${repository.full_name})...`)
+
+  const existingRepository = await knex('github_repositories').where({ full_name: repository.full_name }).first()
+  if (existingRepository) {
+    return knex('github_repositories').where({ full_name: repository.full_name, github_organization_id: orgId }).update(repository).returning('*')
+  } else {
+    return knex('github_repositories').insert({ ...repository, github_organization_id: orgId }).returning('*')
+  }
+}
+
 const getAllGithubOrganizations = knex => async () => {
   debug('Getting all GitHub organizations...')
   return knex('github_organizations').select()
@@ -41,7 +52,8 @@ const initializeStore = (knex) => {
     addProject: addProject(knex),
     addGithubOrganization: addGithubOrganization(knex),
     getAllGithubOrganizations: getAllGithubOrganizations(knex),
-    updateGithubOrganization: updateGithubOrganization(knex)
+    updateGithubOrganization: updateGithubOrganization(knex),
+    upsertGithubRepository: upsertGithubRepository(knex)
   }
 }
 

--- a/src/workflows/index.js
+++ b/src/workflows/index.js
@@ -3,7 +3,7 @@ const { simplifyObject } = require('@ulisesgascon/simplify-object')
 const { github } = require('../providers')
 const { initializeStore } = require('../store')
 const { logger } = require('../utils')
-const { validateGithubOrg } = require('../schemas')
+const { validateGithubOrg, validateGithubListOrgRepos, validateGithubRepository } = require('../schemas')
 
 const mapOrgData = (data) => {
   const mappedData = simplifyObject(data, {
@@ -37,6 +37,44 @@ const mapOrgData = (data) => {
   return mappedData
 }
 
+const mapRepoData = (data) => {
+  const mappedData = simplifyObject(data, {
+    include: [
+      'node_id', 'name', 'full_name',
+      'html_url', 'description', 'fork', 'url',
+      'git_url', 'ssh_url', 'clone_url', 'svn_url',
+      'homepage', 'size', 'stargazers_count', 'watchers_count',
+      'language', 'has_issues', 'has_projects', 'has_downloads',
+      'has_wiki', 'has_pages', 'has_discussions', 'forks_count',
+      'mirror_url', 'archived', 'disabled', 'open_issues_count',
+      'allow_forking', 'is_template', 'web_commit_signoff_required',
+      'topics', 'visibility', 'default_branch', 'allow_squash_merge',
+      'allow_merge_commit', 'allow_rebase_merge', 'allow_auto_merge',
+      'delete_branch_on_merge', 'allow_update_branch', 'use_squash_pr_title_as_default',
+      'squash_merge_commit_message', 'squash_merge_commit_title', 'merge_commit_message',
+      'merge_commit_title', 'network_count', 'subscribers_count'
+    ]
+  })
+  // Additional fields that have different names in the database
+  mappedData.github_repo_id = data.id
+  mappedData.github_created_at = data.created_at
+  mappedData.github_updated_at = data.updated_at
+  mappedData.github_archived_at = data.archived_at
+  // license
+  mappedData.license_key = data.license?.key
+  mappedData.license_name = data.license?.name
+  mappedData.license_spdx_id = data.license?.spdx_id
+  mappedData.license_url = data.license?.url
+  mappedData.license_node_id = data.license?.node_id
+  // Security and analysis
+  mappedData.secret_scanning_status = data.security_and_analysis?.secret_scanning?.status
+  mappedData.secret_scanning_push_protection_status = data.security_and_analysis?.secret_scanning_push_protection?.status
+  mappedData.dependabot_security_updates_status = data.security_and_analysis?.dependabot_security_updates?.status
+  mappedData.secret_scanning_non_provider_patterns_status = data.security_and_analysis?.secret_scanning_non_provider_patterns?.status
+  mappedData.secret_scanning_validity_checks_status = data.security_and_analysis?.secret_scanning_validity_checks?.status
+  return mappedData
+}
+
 const updateGithubOrgs = async (knex) => {
   const { getAllGithubOrganizations, updateGithubOrganization } = initializeStore(knex)
   const organizations = await getAllGithubOrganizations()
@@ -58,6 +96,39 @@ const updateGithubOrgs = async (knex) => {
   logger.log('GitHub organizations updated successfully')
 }
 
+const upsertGithubRepositories = async (knex) => {
+  const { getAllGithubOrganizations, upsertGithubRepository } = initializeStore(knex)
+  const organizations = await getAllGithubOrganizations()
+  debug('Checking stored organizations')
+  if (organizations.length === 0) {
+    throw new Error('No organizations found. Please add organizations/projects before running this workflow.')
+  }
+
+  debug('Fetching repositories for organizations from GitHub API')
+
+  await Promise.all(organizations.map(async (org) => {
+    debug(`Fetching repositories for org (${org.login})`)
+    const repoList = await github.fetchOrgReposListByLogin(org.login)
+    debug(`Got ${repoList.length} repositories for org (${org.login})`)
+    debug('Validating data')
+    validateGithubListOrgRepos(repoList)
+    debug(`Enriching all repositories for org (${org.login})`)
+
+    // Enrich and upsert each repository in parallel
+    await Promise.all(repoList.map(async (repo) => {
+      debug(`Enriching repository (${repo.full_name})`)
+      const repoData = await github.fetchRepoByFullName(repo.full_name)
+      debug(`Validating repository (${repo.full_name})`)
+      validateGithubRepository(repoData)
+      debug(`Transforming repository (${repo.full_name}) data`)
+      const mappedData = mapRepoData(repoData)
+      debug(`Upserting repository (${repo.full_name})`)
+      await upsertGithubRepository(mappedData, org.id)
+    }))
+  }))
+}
+
 module.exports = {
-  updateGithubOrgs
+  updateGithubOrgs,
+  upsertGithubRepositories
 }


### PR DESCRIPTION
### Main Changes
- Add a new CLI workflow `upsert-github-repositories` (969b48e)
- Add a new table `github_repositories` (362ba4a)
- Extended Github provider and store to support github repository operations (24f477e & 7445918)

### Other changes
- Extend utils to support `github_repositories` table (d520eec)
- Add new tests cases for CLI to support `upsert-github-repositories` (97fbf05)
- Update database schema (fe00c8b)


### Changelog
- 362ba4a feat: add migration for `github_repositories` table by @UlisesGascon
- 24f477e feat: add method `fetchOrgReposListByLogin` in GitHub provider by @UlisesGascon
- 7445918 feat: add method `upsertGithubRepository` in GitHub provider by @UlisesGascon
- 969b48e feat: add workflow `upsert-github-repositories` by @UlisesGascon
- d520eec test: extend utils to handle `github_repositories` table by @UlisesGascon
- 97fbf05 test: add coverage for `upsert-github-repositories` workflow by @UlisesGascon
- fe00c8b chore: update database schema by @UlisesGascon
