### PR TITLE
Add cli command `check list`

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ To list all available workflows, use the following command:
 node index.js workflow list
 ```
 
+### Checks
+
+You can list all the implemented checks, use the following command:
+
+```bash
+node index.js check list
+```
 
 ## Debug mode
 

--- a/__tests__/cli/check.test.js
+++ b/__tests__/cli/check.test.js
@@ -1,0 +1,38 @@
+const inquirer = require('inquirer').default
+const knexInit = require('knex')
+const { getConfig } = require('../../src/config')
+
+const { listCheckCommand } = require('../../src/cli')
+const { resetDatabase, getAllComplianceChecks } = require('../../__utils__')
+
+const { dbSettings } = getConfig('test')
+
+describe('check related commands', () => {
+  let knex
+
+  beforeAll(() => {
+    knex = knexInit(dbSettings)
+  })
+  beforeEach(async () => {
+    await resetDatabase(knex)
+    jest.clearAllMocks()
+  })
+  afterEach(jest.clearAllMocks)
+  afterAll(async () => {
+    await resetDatabase(knex)
+    await knex.destroy()
+  })
+  describe('list - Non-Interactive Mode', () => {
+    jest.spyOn(inquirer, 'prompt').mockImplementation(async () => ({}))
+
+    test('Should provide a list of available workflows', async () => {
+      const checks = await getAllComplianceChecks(knex)
+      // Ensure that there are checks available
+      expect(checks.length).not.toBe(0)
+      // Filter relevant checks
+      const relevantChecks = checks.filter(check => check.implementation_status === 'completed')
+      const availableChecksList = await listCheckCommand(knex)
+      await expect(availableChecksList).toEqual(relevantChecks)
+    })
+  })
+})

--- a/__tests__/cli/check.test.js
+++ b/__tests__/cli/check.test.js
@@ -7,32 +7,30 @@ const { resetDatabase, getAllComplianceChecks } = require('../../__utils__')
 
 const { dbSettings } = getConfig('test')
 
-describe('check related commands', () => {
-  let knex
+let knex
 
-  beforeAll(() => {
-    knex = knexInit(dbSettings)
-  })
-  beforeEach(async () => {
-    await resetDatabase(knex)
-    jest.clearAllMocks()
-  })
-  afterEach(jest.clearAllMocks)
-  afterAll(async () => {
-    await resetDatabase(knex)
-    await knex.destroy()
-  })
-  describe('list - Non-Interactive Mode', () => {
-    jest.spyOn(inquirer, 'prompt').mockImplementation(async () => ({}))
+beforeAll(() => {
+  knex = knexInit(dbSettings)
+})
+beforeEach(async () => {
+  await resetDatabase(knex)
+  jest.clearAllMocks()
+})
+afterEach(jest.clearAllMocks)
+afterAll(async () => {
+  await resetDatabase(knex)
+  await knex.destroy()
+})
+describe('list - Non-Interactive Mode', () => {
+  jest.spyOn(inquirer, 'prompt').mockImplementation(async () => ({}))
 
-    test('Should provide a list of available workflows', async () => {
-      const checks = await getAllComplianceChecks(knex)
-      // Ensure that there are checks available
-      expect(checks.length).not.toBe(0)
-      // Filter relevant checks
-      const relevantChecks = checks.filter(check => check.implementation_status === 'completed')
-      const availableChecksList = await listCheckCommand(knex)
-      await expect(availableChecksList).toEqual(relevantChecks)
-    })
+  test('Should provide a list of available workflows', async () => {
+    const checks = await getAllComplianceChecks(knex)
+    // Ensure that there are checks available
+    expect(checks.length).not.toBe(0)
+    // Filter relevant checks
+    const relevantChecks = checks.filter(check => check.implementation_status === 'completed')
+    const availableChecksList = await listCheckCommand(knex)
+    await expect(availableChecksList).toEqual(relevantChecks)
   })
 })

--- a/__utils__/index.js
+++ b/__utils__/index.js
@@ -23,7 +23,10 @@ const addGithubRepo = async (knex, data) => {
   return githubRepo
 }
 
+const getAllComplianceChecks = (knex) => knex('compliance_checks').select('*')
+
 module.exports = {
+  getAllComplianceChecks,
   resetDatabase,
   getAllProjects,
   getAllGithubOrgs,

--- a/index.js
+++ b/index.js
@@ -2,14 +2,14 @@ const { Command } = require('commander')
 const { getConfig } = require('./src/config')
 const { projectCategories, dbSettings } = getConfig()
 const { logger } = require('./src/utils')
-const { runAddProjectCommand, runWorkflowCommand, listWorkflowCommand } = require('./src/cli')
+const { runAddProjectCommand, runWorkflowCommand, listWorkflowCommand, listCheckCommand } = require('./src/cli')
 const knex = require('knex')(dbSettings)
 
 const program = new Command()
 
 const project = program.command('project').description('Manage projects')
 
-// Project commands
+// Project related commands
 project
   .command('add')
   .description('Add a new project')
@@ -27,7 +27,7 @@ project
     }
   })
 
-// Workflow commands
+// Workflows related commands
 const workflow = program.command('workflow').description('Manage workflows')
 
 workflow
@@ -51,4 +51,22 @@ workflow
   .action((options) => {
     listWorkflowCommand(options)
   })
+
+// Checks related commands
+const check = program.command('check').description('Manage checks')
+
+check
+  .command('list')
+  .description('List all available checks')
+  .action(async (options) => {
+    try {
+      await listCheckCommand(knex, options)
+    } catch (error) {
+      logger.error('Error running check:', error.message)
+      process.exit(1)
+    } finally {
+      await knex.destroy()
+    }
+  })
+
 program.parse(process.argv)

--- a/src/cli/checks.js
+++ b/src/cli/checks.js
@@ -2,18 +2,17 @@ const { initializeStore } = require('../store')
 const { logger } = require('../utils')
 
 async function listCheckCommand (knex, options = {}) {
-    const { getAllComplianceChecks } = initializeStore(knex)
-    const checks = await getAllComplianceChecks(knex)
-    const implementedChecks = checks.filter(check => check['implementation_status'] === "completed")
-    implementedChecks.forEach(check => {
-        logger.log(`- ${check['code_name']}: ${check.title}`)
-    })
-    logger.log('------------------------------------')
-    logger.log(`Implemented checks: ${implementedChecks.length}/${checks.length}.`)
-    return implementedChecks
+  const { getAllComplianceChecks } = initializeStore(knex)
+  const checks = await getAllComplianceChecks(knex)
+  const implementedChecks = checks.filter(check => check.implementation_status === 'completed')
+  implementedChecks.forEach(check => {
+    logger.log(`- ${check.code_name}: ${check.title}`)
+  })
+  logger.log('------------------------------------')
+  logger.log(`Implemented checks: ${implementedChecks.length}/${checks.length}.`)
+  return implementedChecks
 }
 
 module.exports = {
-    listCheckCommand
+  listCheckCommand
 }
-

--- a/src/cli/checks.js
+++ b/src/cli/checks.js
@@ -1,0 +1,19 @@
+const { initializeStore } = require('../store')
+const { logger } = require('../utils')
+
+async function listCheckCommand (knex, options = {}) {
+    const { getAllComplianceChecks } = initializeStore(knex)
+    const checks = await getAllComplianceChecks(knex)
+    const implementedChecks = checks.filter(check => check['implementation_status'] === "completed")
+    implementedChecks.forEach(check => {
+        logger.log(`- ${check['code_name']}: ${check.title}`)
+    })
+    logger.log('------------------------------------')
+    logger.log(`Implemented checks: ${implementedChecks.length}/${checks.length}.`)
+    return implementedChecks
+}
+
+module.exports = {
+    listCheckCommand
+}
+

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1,7 +1,9 @@
 const project = require('./project')
 const workflows = require('./workflows')
+const checks = require('./checks')
 
 module.exports = {
   ...project,
-  ...workflows
+  ...workflows,
+  ...checks
 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -46,6 +46,11 @@ const addProject = knex => async (project) => {
   }).returning('*')
 }
 
+const getAllComplianceChecks = knex => async () => {
+  debug('Getting all checks...')
+  return knex('compliance_checks').select().returning('*')
+}
+
 const initializeStore = (knex) => {
   debug('Initializing store...')
   return {
@@ -53,7 +58,8 @@ const initializeStore = (knex) => {
     addGithubOrganization: addGithubOrganization(knex),
     getAllGithubOrganizations: getAllGithubOrganizations(knex),
     updateGithubOrganization: updateGithubOrganization(knex),
-    upsertGithubRepository: upsertGithubRepository(knex)
+    upsertGithubRepository: upsertGithubRepository(knex),
+    getAllComplianceChecks: getAllComplianceChecks(knex)
   }
 }
 


### PR DESCRIPTION
### Main Changes
- Add store utils for retrieving compliance checks (2b91d9b)
- Add cli check commands, and include the option to list available checks by doing `check lists` (dac8fc0)

### Other changes
- Add new tests cases to cover this changes (6ffb626), also the utils were extended (1cf7f63)
- Add list checks information into the documentation (941cd53)
- Lint files (3117d07)

### Changelog
- 2b91d9b feat: add store utils for retrieving compliance checks by @UlisesGascon
- dac8fc0 feat: add cli checks related commands (listing) by @UlisesGascon
- 1cf7f63 test: extend utils to handle compliance checks data by @UlisesGascon
- 6ffb626 test: add test cases for listing available checks using CLI by @UlisesGascon
- 941cd53 doc: add list checks information by @UlisesGascon
- 3117d07 chore: lint files by @UlisesGascon