### PR TITLE
Add CLI command `check run`

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,13 @@ You can list all the implemented checks, use the following command:
 node index.js check list
 ```
 
+You can any implemented check at any time by running the following command:
+
+```bash
+node index.js check run [--name <name>]
+```
+
+
 ## Debug mode
 
 This project uses the [debug library](https://www.npmjs.com/package/debug), so you can always use the environmental variable `DEBUG=*` to print more detailed information of the execution.

--- a/__tests__/cli/check.test.js
+++ b/__tests__/cli/check.test.js
@@ -34,3 +34,13 @@ describe('list - Non-Interactive Mode', () => {
     await expect(availableChecksList).toEqual(relevantChecks)
   })
 })
+
+describe('run - Interactive Mode', () => {
+  test.todo('Should run the check when a valid name is provided')
+})
+describe('run - Non-Interactive Mode', () => {
+  test.todo('Should throw an error when invalid name is provided')
+  test.todo('Should throw an error when no name is provided')
+  test.todo('Should throw an error when the check is not implemented')
+  test.todo('Should run the check when a valid name is provided')
+})

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const { Command } = require('commander')
 const { getConfig } = require('./src/config')
 const { projectCategories, dbSettings } = getConfig()
 const { logger } = require('./src/utils')
-const { runAddProjectCommand, runWorkflowCommand, listWorkflowCommand, listCheckCommand } = require('./src/cli')
+const { runAddProjectCommand, runWorkflowCommand, listWorkflowCommand, listCheckCommand, runCheckCommand } = require('./src/cli')
 const knex = require('knex')(dbSettings)
 
 const program = new Command()
@@ -61,6 +61,21 @@ check
   .action(async (options) => {
     try {
       await listCheckCommand(knex, options)
+    } catch (error) {
+      logger.error('Error running check:', error.message)
+      process.exit(1)
+    } finally {
+      await knex.destroy()
+    }
+  })
+
+check
+  .command('run')
+  .description('Run a check')
+  .option('--name <name>', 'Name of the check')
+  .action(async (options) => {
+    try {
+      await runCheckCommand(knex, options)
     } catch (error) {
       logger.error('Error running check:', error.message)
       process.exit(1)

--- a/src/checks/index.js
+++ b/src/checks/index.js
@@ -1,0 +1,20 @@
+const { readdirSync } = require('fs')
+const { join } = require('path')
+const debug = require('debug')('checks:index')
+
+// This will load all the files in the complianceChecks directory and export them as an object. It works similar to require-all
+debug('Loading compliance check files...')
+const checksPath = join(__dirname, 'complianceChecks')
+const files = readdirSync(checksPath)
+const jsFiles = files.filter(file => file.endsWith('.js'))
+const checks = {}
+for (const file of jsFiles) {
+  debug(`Loading ${file}...`)
+  const [fileName] = file.split('.')
+  const fileContent = require(join(checksPath, file))
+  checks[fileName] = fileContent
+}
+
+debug('Checks files loaded')
+
+module.exports = checks

--- a/src/cli/checks.js
+++ b/src/cli/checks.js
@@ -1,5 +1,8 @@
+const inquirer = require('inquirer').default
 const { initializeStore } = require('../store')
 const { logger } = require('../utils')
+const checks = require('../checks')
+const debug = require('debug')('cli:checks')
 
 async function listCheckCommand (knex, options = {}) {
   const { getAllComplianceChecks } = initializeStore(knex)
@@ -13,6 +16,33 @@ async function listCheckCommand (knex, options = {}) {
   return implementedChecks
 }
 
+async function runCheckCommand (knex, options = {}) {
+  const { getAllComplianceChecks } = initializeStore(knex)
+  const complianceChecks = await getAllComplianceChecks(knex)
+  const implementedChecks = complianceChecks.filter(check => check.implementation_status === 'completed')
+  const validCommandNames = implementedChecks.map((item) => item.code_name)
+
+  if (Object.keys(options).length && !validCommandNames.includes(options.name)) {
+    throw new Error('Invalid check name. Please enter a valid check name.')
+  }
+
+  const answers = options.name
+    ? options
+    : await inquirer.prompt([
+      {
+        type: 'list',
+        name: 'name',
+        message: 'What is the name (code_name) of the check?',
+        choices: validCommandNames,
+        when: () => !options.name
+      }
+    ])
+
+  debug('Running check with code_name:', answers.name)
+  checks[answers.name](knex)
+}
+
 module.exports = {
-  listCheckCommand
+  listCheckCommand,
+  runCheckCommand
 }


### PR DESCRIPTION
### Main Changes
- Add CLI command `check run` (887671d)

### Other changes
- Add pending tests related to the new CLI command (1b02524)
- Add a helper to auto-import implemented checks with `check run` (36c7198)
- Include documentation about how to use the CLI command `check run` (7237da3)
- Add placeholder file for the complianceChecks folder (9357f53)

### Changelog
- 1b02524 test: add pending tests to the test suite by @UlisesGascon
- 36c7198 feat: add a helper to autoimport all the checks by @UlisesGascon
- 887671d feat: add CLI command check run by @UlisesGascon
- 7237da3 docs: include information about check run CLI command by @UlisesGascon
- 9357f53 fix: add placeholder file by @UlisesGascon