### PR TITLE
feat: add script to export `compliance_checks` table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ dist
 
 # CUSTOM
 IGNORE/
+output

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "db:migrate": "knex migrate:latest",
     "db:rollback": "knex migrate:rollback",
     "db:generate-schema": "docker-compose run schema-dump",
+    "db:export-checks": "node scripts/export-checks.js",
     "db:seed": "knex seed:run"
   },
   "keywords": [],

--- a/scripts/export-checks.js
+++ b/scripts/export-checks.js
@@ -1,0 +1,12 @@
+const { writeFileSync } = require('fs')
+const { getConfig } = require('../src/config')
+const { dbSettings } = getConfig()
+const knex = require('knex')(dbSettings)
+const { join } = require('path')
+
+;(async () => {
+  const checks = await knex('compliance_checks').select()
+  writeFileSync(join(process.cwd(), 'output', 'checks.json'), JSON.stringify(checks, null, 2))
+  console.log('Checks exported to checks.json')
+  await knex.destroy()
+})()


### PR DESCRIPTION
### Main Changes
- The resulting file does not include sensitive information (as it is already in the migrations scripts) and it is hidden from the git history too
- Add npm command to run this `npm run db:export-checks`