### PR TITLE
Add check `softwareDesignTraining`

### DIFF
--- a/__tests__/checks/softwareDesignTraining.test.js
+++ b/__tests__/checks/softwareDesignTraining.test.js
@@ -1,0 +1,114 @@
+const knexInit = require('knex')
+const { getConfig } = require('../../src/config')
+const softwareDesignTraining = require('../../src/checks/complianceChecks/softwareDesignTraining')
+const {
+  resetDatabase, addProject, getAllResults, getAllTasks, getAllAlerts,
+  addAlert, addTask, addResult, getCheckByCodeName, addSSoftwareDesignTraining, getAllSoftwareDesignTrainings
+} = require('../../__utils__')
+
+const { dbSettings } = getConfig('test')
+
+let knex
+let project
+let check
+
+beforeAll(async () => {
+  knex = knexInit(dbSettings)
+  check = await getCheckByCodeName(knex, 'softwareDesignTraining')
+})
+
+beforeEach(async () => {
+  await resetDatabase(knex)
+  project = await addProject(knex, { name: 'project', category: 'impact' })
+})
+
+afterAll(async () => {
+  await knex.destroy()
+})
+
+describe('Integration: softwareDesignTraining', () => {
+  test('Should add results without alerts or tasks', async () => {
+    // Add a passed check scenario
+    await addSSoftwareDesignTraining(knex, { project_id: project.id, description: 'learning accomplished', training_date: new Date().toISOString() })
+    let trainings = await getAllSoftwareDesignTrainings(knex)
+    expect(trainings.length).toBe(1)
+    // Check that the database is empty
+    let results = await getAllResults(knex)
+    expect(results.length).toBe(0)
+    let alerts = await getAllAlerts(knex)
+    expect(alerts.length).toBe(0)
+    let tasks = await getAllTasks(knex)
+    expect(tasks.length).toBe(0)
+    // Run the check
+    await expect(softwareDesignTraining(knex)).resolves.toBeUndefined()
+    // Check that the database has the expected results
+    trainings = await getAllSoftwareDesignTrainings(knex)
+    expect(trainings.length).toBe(1)
+    results = await getAllResults(knex)
+    expect(results.length).toBe(1)
+    expect(results[0].status).toBe('passed')
+    expect(results[0].compliance_check_id).toBe(check.id)
+    alerts = await getAllAlerts(knex)
+    expect(alerts.length).toBe(0)
+    tasks = await getAllTasks(knex)
+    expect(tasks.length).toBe(0)
+  })
+  test('Should delete (previous alerts and tasks) and add results', async () => {
+    // Add a passed check scenario
+    await addSSoftwareDesignTraining(knex, { project_id: project.id, description: 'learning accomplished', training_date: new Date().toISOString() })
+    // Add previous alerts and tasks
+    await addAlert(knex, { compliance_check_id: check.id, project_id: project.id, title: 'existing', description: 'existing', severity: 'critical' })
+    await addTask(knex, { compliance_check_id: check.id, project_id: project.id, title: 'existing', description: 'existing', severity: 'critical' })
+    // Check that the database has the expected results
+    const trainings = await getAllSoftwareDesignTrainings(knex)
+    expect(trainings.length).toBe(1)
+    let results = await getAllResults(knex)
+    expect(results.length).toBe(0)
+    let alerts = await getAllAlerts(knex)
+    expect(alerts.length).toBe(1)
+    expect(alerts[0].compliance_check_id).toBe(check.id)
+    let tasks = await getAllTasks(knex)
+    expect(tasks.length).toBe(1)
+    expect(tasks[0].compliance_check_id).toBe(check.id)
+    // Run the check
+    await expect(softwareDesignTraining(knex)).resolves.toBeUndefined()
+    // Check that the database has the expected results
+    results = await getAllResults(knex)
+    expect(results.length).toBe(1)
+    expect(results[0].status).toBe('passed')
+    expect(results[0].compliance_check_id).toBe(check.id)
+    alerts = await getAllAlerts(knex)
+    expect(alerts.length).toBe(0)
+    tasks = await getAllTasks(knex)
+    expect(tasks.length).toBe(0)
+  })
+  test('Should add (alerts and tasks) and update results', async () => {
+    await addResult(knex, { compliance_check_id: check.id, project_id: project.id, status: 'failed', rationale: 'failed previously', severity: 'critical' })
+    // Check that the database is empty
+    let results = await getAllResults(knex)
+    expect(results.length).toBe(1)
+    expect(results[0].compliance_check_id).toBe(check.id)
+    let trainings = await getAllSoftwareDesignTrainings(knex)
+    expect(trainings.length).toBe(0)
+    let alerts = await getAllAlerts(knex)
+    expect(alerts.length).toBe(0)
+    let tasks = await getAllTasks(knex)
+    expect(tasks.length).toBe(0)
+    // Run the check
+    await expect(softwareDesignTraining(knex)).resolves.toBeUndefined()
+    // Check that the database has the expected results
+    results = await getAllResults(knex)
+    expect(results.length).toBe(1)
+    expect(results[0].status).toBe('failed')
+    expect(results[0].rationale).not.toBe('failed previously')
+    expect(results[0].compliance_check_id).toBe(check.id)
+    trainings = await getAllSoftwareDesignTrainings(knex)
+    expect(trainings.length).toBe(0)
+    alerts = await getAllAlerts(knex)
+    expect(alerts.length).toBe(1)
+    expect(alerts[0].compliance_check_id).toBe(check.id)
+    tasks = await getAllTasks(knex)
+    expect(tasks.length).toBe(1)
+    expect(tasks[0].compliance_check_id).toBe(check.id)
+  })
+})

--- a/__tests__/checks/validators.test.js
+++ b/__tests__/checks/validators.test.js
@@ -153,11 +153,11 @@ describe('softwareDesignTraining', () => {
     trainings = [
       {
         project_id: 1,
-        date: new Date().toISOString()
+        training_date: new Date().toISOString()
       },
       {
         project_id: 2,
-        date: new Date().toISOString()
+        training_date: new Date().toISOString()
       }
     ]
 
@@ -206,7 +206,7 @@ describe('softwareDesignTraining', () => {
     })
   })
   it('Should generate a failed result if the project has a software design training but it is out of date', () => {
-    trainings[0].date = '2019-01-01'
+    trainings[0].training_date = '2019-01-01'
     const analysis = softwareDesignTraining({ trainings, check, projects })
     expect(analysis).toEqual({
       alerts: [

--- a/__tests__/checks/validators.test.js
+++ b/__tests__/checks/validators.test.js
@@ -148,9 +148,9 @@ describe('githubOrgMFA', () => {
 })
 
 describe('softwareDesignTraining', () => {
-  let softwareDesignTrainings, check, projects
+  let trainings, check, projects
   beforeEach(() => {
-    softwareDesignTrainings = [
+    trainings = [
       {
         project_id: 1,
         date: new Date().toISOString()
@@ -183,7 +183,7 @@ describe('softwareDesignTraining', () => {
   })
 
   it('Should generate a passed result if the project has a software design training and it is up to date', () => {
-    const analysis = softwareDesignTraining({ softwareDesignTrainings, check, projects })
+    const analysis = softwareDesignTraining({ trainings, check, projects })
     expect(analysis).toEqual({
       alerts: [],
       results: [
@@ -206,8 +206,8 @@ describe('softwareDesignTraining', () => {
     })
   })
   it('Should generate a failed result if the project has a software design training but it is out of date', () => {
-    softwareDesignTrainings[0].date = '2019-01-01'
-    const analysis = softwareDesignTraining({ softwareDesignTrainings, check, projects })
+    trainings[0].date = '2019-01-01'
+    const analysis = softwareDesignTraining({ trainings, check, projects })
     expect(analysis).toEqual({
       alerts: [
         {
@@ -246,8 +246,8 @@ describe('softwareDesignTraining', () => {
     })
   })
   it('Should generate a failed result if the project does not have a software design training', () => {
-    softwareDesignTrainings = []
-    const analysis = softwareDesignTraining({ softwareDesignTrainings, check, projects })
+    trainings = []
+    const analysis = softwareDesignTraining({ trainings, check, projects })
     expect(analysis).toEqual({
       alerts: [
         {
@@ -303,7 +303,7 @@ describe('softwareDesignTraining', () => {
     check.level_active_status = 'n/a'
     check.level_incubating_status = 'n/a'
     check.level_retiring_status = 'n/a'
-    const analysis = softwareDesignTraining({ softwareDesignTrainings, check, projects })
+    const analysis = softwareDesignTraining({ trainings, check, projects })
     expect(analysis).toEqual({
       alerts: [],
       results: [],

--- a/__utils__/index.js
+++ b/__utils__/index.js
@@ -1,4 +1,5 @@
 const resetDatabase = async (knex) => {
+  await knex.raw('TRUNCATE TABLE software_design_training RESTART IDENTITY CASCADE')
   await knex.raw('TRUNCATE TABLE compliance_checks_results RESTART IDENTITY CASCADE')
   await knex.raw('TRUNCATE TABLE compliance_checks_tasks RESTART IDENTITY CASCADE')
   await knex.raw('TRUNCATE TABLE compliance_checks_alerts RESTART IDENTITY CASCADE')
@@ -50,6 +51,13 @@ const getCheckByCodeName = async (knex, codeName) => {
   return check
 }
 
+const addSSoftwareDesignTraining = async (knex, data) => {
+  const [training] = await knex('software_design_training').insert(data).returning('*')
+  return training
+}
+
+const getAllSoftwareDesignTrainings = (knex) => knex('software_design_training').select('*')
+
 module.exports = {
   getAllComplianceChecks,
   resetDatabase,
@@ -65,5 +73,7 @@ module.exports = {
   addAlert,
   addTask,
   addResult,
-  getCheckByCodeName
+  getCheckByCodeName,
+  addSSoftwareDesignTraining,
+  getAllSoftwareDesignTrainings
 }

--- a/src/checks/complianceChecks/softwareDesignTraining.js
+++ b/src/checks/complianceChecks/softwareDesignTraining.js
@@ -1,0 +1,28 @@
+const validators = require('../validators')
+const { initializeStore } = require('../../store')
+const debug = require('debug')('checks:softwareDesignTraining')
+
+module.exports = async (knex) => {
+  const {
+    getAllSSoftwareDesignTrainings, getCheckByCodeName,
+    getAllProjects, addAlert, addTask, upsertComplianceCheckResult,
+    deleteAlertsByComplianceCheckId, deleteTasksByComplianceCheckId
+  } = initializeStore(knex)
+  debug('Collecting relevant data...')
+  const check = await getCheckByCodeName('softwareDesignTraining')
+  const trainings = await getAllSSoftwareDesignTrainings()
+  const projects = await getAllProjects()
+
+  debug('Extracting the validation results...')
+  const analysis = validators.softwareDesignTraining({ trainings, check, projects })
+  debug('Deleting previous alerts and tasks to avoid orphaned records...')
+  await deleteAlertsByComplianceCheckId(check.id)
+  await deleteTasksByComplianceCheckId(check.id)
+
+  debug('Upserting the new results...')
+  await Promise.all(analysis.results.map(result => upsertComplianceCheckResult(result)))
+
+  debug('Inserting the new Alerts and Tasks...')
+  await Promise.all(analysis.alerts.map(alert => addAlert(alert)))
+  await Promise.all(analysis.tasks.map(task => addTask(task)))
+}

--- a/src/checks/validators/githubOrgMFA.js
+++ b/src/checks/validators/githubOrgMFA.js
@@ -4,7 +4,7 @@ const { getSeverityFromPriorityGroup, isCheckApplicableToProjectCategory, groupA
 const groupByProject = groupArrayItemsByCriteria('project_id')
 
 // @see: https://github.com/secure-dashboards/openjs-foundation-dashboard/issues/43
-module.exports = ({ organizations, check, projects }) => {
+module.exports = ({ organizations=[], check, projects=[] }) => {
   debug('Validating GitHub organizations MFA...')
   debug('Grouping organizations by project...')
   const organizationsGroupedByProject = groupByProject(organizations)

--- a/src/checks/validators/githubOrgMFA.js
+++ b/src/checks/validators/githubOrgMFA.js
@@ -4,7 +4,7 @@ const { getSeverityFromPriorityGroup, isCheckApplicableToProjectCategory, groupA
 const groupByProject = groupArrayItemsByCriteria('project_id')
 
 // @see: https://github.com/secure-dashboards/openjs-foundation-dashboard/issues/43
-module.exports = ({ organizations=[], check, projects=[] }) => {
+module.exports = ({ organizations = [], check, projects = [] }) => {
   debug('Validating GitHub organizations MFA...')
   debug('Grouping organizations by project...')
   const organizationsGroupedByProject = groupByProject(organizations)

--- a/src/checks/validators/softwareDesignTraining.js
+++ b/src/checks/validators/softwareDesignTraining.js
@@ -3,7 +3,7 @@ const { isCheckApplicableToProjectCategory, getSeverityFromPriorityGroup, isDate
 
 const expirationPolicy = '6m'
 
-module.exports = ({ trainings=[], check, projects }) => {
+module.exports = ({ trainings = [], check, projects }) => {
   debug('Validating Software Design Training...')
   const alerts = []
   const results = []

--- a/src/checks/validators/softwareDesignTraining.js
+++ b/src/checks/validators/softwareDesignTraining.js
@@ -3,7 +3,7 @@ const { isCheckApplicableToProjectCategory, getSeverityFromPriorityGroup, isDate
 
 const expirationPolicy = '6m'
 
-module.exports = ({ softwareDesignTrainings, check, projects }) => {
+module.exports = ({ trainings=[], check, projects }) => {
   debug('Validating Software Design Training...')
   const alerts = []
   const results = []
@@ -28,7 +28,7 @@ module.exports = ({ softwareDesignTrainings, check, projects }) => {
     const task = { ...baseData }
     const alert = { ...baseData }
 
-    const trainingDetails = softwareDesignTrainings.find(training => training.project_id === project.id)
+    const trainingDetails = trainings.find(training => training.project_id === project.id)
     if (!trainingDetails) {
       result.status = 'failed'
       result.rationale = 'No Software Design Training found'

--- a/src/checks/validators/softwareDesignTraining.js
+++ b/src/checks/validators/softwareDesignTraining.js
@@ -3,7 +3,7 @@ const { isCheckApplicableToProjectCategory, getSeverityFromPriorityGroup, isDate
 
 const expirationPolicy = '6m'
 
-module.exports = ({ trainings = [], check, projects }) => {
+module.exports = ({ trainings = [], check, projects = [] }) => {
   debug('Validating Software Design Training...')
   const alerts = []
   const results = []
@@ -36,7 +36,7 @@ module.exports = ({ trainings = [], check, projects }) => {
       alert.description = `Check the details on ${check.details_url}`
       task.title = 'Create a Software Design Training'
       task.description = `Check the details on ${check.details_url}`
-    } else if (trainingDetails && !isDateWithinPolicy(trainingDetails.date, expirationPolicy)) {
+    } else if (trainingDetails?.training_date && !isDateWithinPolicy(trainingDetails.training_date, expirationPolicy)) {
       result.status = 'failed'
       result.rationale = 'Software Design Training is out of date'
       alert.title = 'Software Design Training is out of date'

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -90,6 +90,11 @@ const upsertComplianceCheckResult = knex => async (result) => {
   }
 }
 
+const getAllSSoftwareDesignTrainings = knex => async () => {
+  debug('Getting all software design trainings...')
+  return knex('software_design_training').select().returning('*')
+}
+
 const initializeStore = (knex) => {
   debug('Initializing store...')
   return {
@@ -105,7 +110,8 @@ const initializeStore = (knex) => {
     deleteAlertsByComplianceCheckId: deleteAlertsByComplianceCheckId(knex),
     addAlert: addAlert(knex),
     addTask: addTask(knex),
-    upsertComplianceCheckResult: upsertComplianceCheckResult(knex)
+    upsertComplianceCheckResult: upsertComplianceCheckResult(knex),
+    getAllSSoftwareDesignTrainings: getAllSSoftwareDesignTrainings(knex)
   }
 }
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -74,6 +74,11 @@ const isDateWithinPolicy = (targetDate, policy) => {
     throw new Error('Policy is required')
   }
 
+  // Ensure targetDate is a string
+  if (typeof targetDate !== 'string') {
+    targetDate = targetDate.toISOString()
+  }
+
   const targetDateObj = parseISO(targetDate) // Parse ISO string into Date object
   let expirationDate
 


### PR DESCRIPTION
### Main Changes
- Add check softwareDesignTraining (25f6fb2)

### Other Changes

- Rename properties and ensure default values (a381ab0)
- Lint files (e05a90d)
- Update wrong property reference (9afbb84)
- Make the policy date check more resilient (210f55d)
- Extend store to support `software_design_training` ops (d90cb8b)

### Context
- Related https://github.com/secure-dashboards/openjs-foundation-dashboard/issues/52

### Changelog
- a381ab0 chore: rename properties and ensure default values by @UlisesGascon
- e05a90d chore: linting by @UlisesGascon
- 9afbb84 test: update wrong property reference by @UlisesGascon
- 210f55d feat: make the policy date check more resilient by @UlisesGascon
- d90cb8b feat: extend store to support `software_design_training` ops by @UlisesGascon
- 25f6fb2 feat: add check softwareDesignTraining by @UlisesGascon